### PR TITLE
Add a report for the latest catalog leaf per package identity

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.403
+        dotnet-version: 5.0.102
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/src/CatalogCrawler/CatalogCrawler.csproj
+++ b/src/CatalogCrawler/CatalogCrawler.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <AssemblyName>Knapcode.CatalogCrawler</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
@@ -35,6 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="NuGet.Versioning" Version="5.8.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
   </ItemGroup>
 

--- a/src/CatalogCrawler/Commands/UpdateReportsCommandHandler.cs
+++ b/src/CatalogCrawler/Commands/UpdateReportsCommandHandler.cs
@@ -116,6 +116,11 @@ namespace Knapcode.CatalogCrawler
                 await csvReportUpdater.UpdateAsync(new CatalogLeafCountByTypeReportVisitor());
             }
 
+            if (reports == null || reports.Contains(ReportName.LatestCatalogLeafByPackage))
+            {
+                await csvReportUpdater.UpdateAsync(new LatestCatalogLeafByPackageVisitor());
+            }
+
             return 0;
         }
     }

--- a/src/CatalogCrawler/Reports/CatalogLeafCountByTypeReportUpdater.cs
+++ b/src/CatalogCrawler/Reports/CatalogLeafCountByTypeReportUpdater.cs
@@ -30,14 +30,15 @@ namespace Knapcode.CatalogCrawler
                     {
                         PackageDetails = x.Count(x => x.Type == "nuget:PackageDetails"),
                         PackageDelete = x.Count(x => x.Type == "nuget:PackageDelete"),
-                    });
+                    })
+                .AsReadOnly();
 
             if (result.Sum(x => x.Value.PackageDetails + x.Value.PackageDelete) != catalogPage.Items.Count)
             {
                 throw new InvalidOperationException("Not all catalog leaf items had a known type.");
             }
 
-            return Task.FromResult<IReadOnlyDictionary<DateTimeOffset, CatalogLeafCountByType>>(result);
+            return Task.FromResult(result);
         }
     }
 }

--- a/src/CatalogCrawler/Reports/ExtensionMethods.cs
+++ b/src/CatalogCrawler/Reports/ExtensionMethods.cs
@@ -2,6 +2,7 @@
 using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
 using System;
+using System.Collections.Generic;
 
 namespace Knapcode.CatalogCrawler
 {
@@ -22,6 +23,12 @@ namespace Knapcode.CatalogCrawler
         {
             var options = new TypeConverterOptions { Formats = new[] { "O" } };
             cache.AddOptions<DateTimeOffset>(options);
+        }
+
+        public static IReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(
+            this IDictionary<TKey, TValue> dictionary)
+        {
+            return (IReadOnlyDictionary<TKey, TValue>)dictionary;
         }
     }
 }

--- a/src/CatalogCrawler/Reports/LatestCatalogLeafByPackage.cs
+++ b/src/CatalogCrawler/Reports/LatestCatalogLeafByPackage.cs
@@ -13,5 +13,10 @@ namespace Knapcode.CatalogCrawler
         /// The commit timestamp of this catalog item.
         /// </summary>
         public DateTimeOffset CommitTimestamp { get; set; }
+
+        /// <summary>
+        /// The URL to fetch the catalog leaf.
+        /// </summary>
+        public string CatalogLeafUrl { get; set; }
     }
 }

--- a/src/CatalogCrawler/Reports/LatestCatalogLeafByPackage.cs
+++ b/src/CatalogCrawler/Reports/LatestCatalogLeafByPackage.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Knapcode.CatalogCrawler
+{
+    class LatestCatalogLeafByPackage
+    {
+        /// <summary>
+        /// The type of the catalog item: "nuget:PackageDetails" or "nuget:PackageDelete".
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The commit timestamp of this catalog item.
+        /// </summary>
+        public DateTimeOffset CommitTimestamp { get; set; }
+    }
+}

--- a/src/CatalogCrawler/Reports/LatestCatalogLeafByPackageReportUpdater.cs
+++ b/src/CatalogCrawler/Reports/LatestCatalogLeafByPackageReportUpdater.cs
@@ -38,6 +38,7 @@ namespace Knapcode.CatalogCrawler
             {
                 Type = latestLeaf.Type,
                 CommitTimestamp = latestLeaf.CommitTimestamp,
+                CatalogLeafUrl = latestLeaf.Url,
             };
         }
     }

--- a/src/CatalogCrawler/Reports/LatestCatalogLeafByPackageReportUpdater.cs
+++ b/src/CatalogCrawler/Reports/LatestCatalogLeafByPackageReportUpdater.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Versioning;
+
+namespace Knapcode.CatalogCrawler
+{
+    class LatestCatalogLeafByPackageVisitor : ICsvAggregateReportUpdater<PackageIdentityKey, LatestCatalogLeafByPackage>
+    {
+        public ReportName Name => ReportName.LatestCatalogLeafByPackage;
+        public IComparer<PackageIdentityKey> KeyComparer => PackageIdentityKeyComparer.Default;
+
+        public Task<IReadOnlyDictionary<PackageIdentityKey, LatestCatalogLeafByPackage>> GetRecordsAsync(CatalogPage catalogPage)
+        {
+            var result = catalogPage
+                .Items
+                .GroupBy(x => new PackageIdentityKey
+                {
+                    PackageId = x.Id,
+                    PackageVersion = NuGetVersion.Parse(x.Version)
+                })
+                .ToDictionary(x => x.Key, ToLatestCatalogLeafByPackage);
+
+            return Task.FromResult((IReadOnlyDictionary<PackageIdentityKey, LatestCatalogLeafByPackage>)result);
+        }
+
+        public LatestCatalogLeafByPackage Merge(LatestCatalogLeafByPackage existingValue, LatestCatalogLeafByPackage newValue)
+        {
+            return newValue;
+        }
+
+        private LatestCatalogLeafByPackage ToLatestCatalogLeafByPackage(IGrouping<PackageIdentityKey, CatalogLeafItem> group)
+        {
+            var latestLeaf = group.OrderByDescending(g => g.CommitTimestamp).First();
+
+            return new LatestCatalogLeafByPackage
+            {
+                Type = latestLeaf.Type,
+                CommitTimestamp = latestLeaf.CommitTimestamp,
+            };
+        }
+    }
+}

--- a/src/CatalogCrawler/Reports/LatestCatalogLeafByPackageReportUpdater.cs
+++ b/src/CatalogCrawler/Reports/LatestCatalogLeafByPackageReportUpdater.cs
@@ -19,9 +19,10 @@ namespace Knapcode.CatalogCrawler
                     PackageId = x.Id,
                     PackageVersion = NuGetVersion.Parse(x.Version)
                 })
-                .ToDictionary(x => x.Key, ToLatestCatalogLeafByPackage);
+                .ToDictionary(x => x.Key, ToLatestCatalogLeafByPackage)
+                .AsReadOnly();
 
-            return Task.FromResult((IReadOnlyDictionary<PackageIdentityKey, LatestCatalogLeafByPackage>)result);
+            return Task.FromResult(result);
         }
 
         public LatestCatalogLeafByPackage Merge(LatestCatalogLeafByPackage existingValue, LatestCatalogLeafByPackage newValue)

--- a/src/CatalogCrawler/Reports/NuGetVersionConverter.cs
+++ b/src/CatalogCrawler/Reports/NuGetVersionConverter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using CsvHelper;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+using NuGet.Versioning;
+
+namespace Knapcode.CatalogCrawler
+{
+    public class NuGetVersionConverter : TypeConverter
+    {
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+        {
+            return NuGetVersion.Parse(text);
+        }
+
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+        {
+            if (value is not NuGetVersion version)
+            {
+                throw new ArgumentException($"The value must have a type of {nameof(NuGetVersion)}", nameof(value));
+            }
+
+            return version.ToNormalizedString();
+        }
+    }
+}

--- a/src/CatalogCrawler/Reports/PackageIdentityKey.cs
+++ b/src/CatalogCrawler/Reports/PackageIdentityKey.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using CsvHelper.Configuration.Attributes;
+using CsvHelper.TypeConversion;
+using NuGet.Versioning;
+
+namespace Knapcode.CatalogCrawler
+{
+    record PackageIdentityKey
+    {
+        public string PackageId { get; init; }
+
+        [TypeConverter(typeof(NuGetVersionConverter))]
+        public NuGetVersion PackageVersion { get; init; }
+    }
+
+    class PackageIdentityKeyComparer : IComparer<PackageIdentityKey>
+    {
+        public static readonly PackageIdentityKeyComparer Default = new PackageIdentityKeyComparer();
+
+        public int Compare(PackageIdentityKey x, PackageIdentityKey y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (ReferenceEquals(x, null))
+            {
+                return -1;
+            }
+
+            if (ReferenceEquals(y, null))
+            {
+                return 1;
+            }
+
+            int result = StringComparer.OrdinalIgnoreCase.Compare(x.PackageId, y.PackageId);
+
+            if (result == 0)
+            {
+                result = VersionComparer.Default.Compare(x.PackageVersion, y.PackageVersion);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/CatalogCrawler/Reports/PackageIdentityKey.cs
+++ b/src/CatalogCrawler/Reports/PackageIdentityKey.cs
@@ -20,6 +20,7 @@ namespace Knapcode.CatalogCrawler
 
         public int Compare(PackageIdentityKey x, PackageIdentityKey y)
         {
+            // See: https://github.com/NuGet/NuGet.Client/blob/27e64ba7b38abda73ac20173eb6ffaf8b1c2d3d7/src/NuGet.Core/NuGet.Packaging/Core/comparers/PackageIdentityComparer.cs#L89-L117
             if (ReferenceEquals(x, y))
             {
                 return 0;

--- a/src/CatalogCrawler/Reports/ReportName.cs
+++ b/src/CatalogCrawler/Reports/ReportName.cs
@@ -5,5 +5,6 @@
         DeletedPackages,
         CatalogLeafCount,
         CatalogLeafCountByType,
+        LatestCatalogLeafByPackage,
     }
 }

--- a/test/CatalogCrawler.Test/CatalogCrawler.Test.csproj
+++ b/test/CatalogCrawler.Test/CatalogCrawler.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
I'm still generating the report locally to see how big it will be. I'll reconsider the approach if the final report gets near the size limit of 100MB.

Addresses https://github.com/joelverhagen/CatalogCrawler/issues/1